### PR TITLE
Use class check to see if FabricLoader class exists rather than based on Fabric Base Event Module being present

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,6 @@ fabric_version=0.89.0+1.9.17+1.20.1
 	loader_version=1.20.1-47.1.65
 
 # Mod Properties
-	mod_version = 1.2.0
+	mod_version = 1.2.1
 	maven_group = com.github.dima_dencep.mods
 	archives_base_name = nanoliveconfig

--- a/src/main/java/net/caffeinemc/caffeineconfig/CaffeineConfig.java
+++ b/src/main/java/net/caffeinemc/caffeineconfig/CaffeineConfig.java
@@ -199,12 +199,10 @@ public final class CaffeineConfig {
         }
     }
 
-    private static final boolean fabricApiLoaded = LoadingModList.get().getModFileById("fabric_api_base") != null;
-
     private void applyModOverrides(String jsonKey) {
         forge$applyModOverrides(jsonKey);
-        if(fabricApiLoaded)
-            fabric$applyModOverrides(jsonKey);
+
+        if(FabricLoaderChecker.HAS_FABRIC_LOADER) fabric$applyModOverrides(jsonKey);
     }
 
     private void forge$applyModOverrides(String jsonKey) {

--- a/src/main/java/net/caffeinemc/caffeineconfig/FabricLoaderChecker.java
+++ b/src/main/java/net/caffeinemc/caffeineconfig/FabricLoaderChecker.java
@@ -1,0 +1,15 @@
+package net.caffeinemc.caffeineconfig;
+
+public class FabricLoaderChecker {
+    public static final boolean HAS_FABRIC_LOADER = hasFabricLoader();
+
+    private static boolean hasFabricLoader() {
+        try {
+            Class.forName("net.fabricmc.loader.api.FabricLoader");
+
+            return true;
+        } catch (Throwable throwable) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Based on the latest method and fixes issues with checking in 1.20.1.

Such targets the main branch temporarily but a new branch should be made for this and such fixes issues with the use of Forgifed Fabric API with out connector installed.